### PR TITLE
TROC-4: python 2.7 no longer supported on github actions

### DIFF
--- a/.github/workflows/daily-develop-build.yml
+++ b/.github/workflows/daily-develop-build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Run with ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/pseudo-nightly-build.yml
+++ b/.github/workflows/pseudo-nightly-build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Run with ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     name: Run with ${{ matrix.python-version }}
     steps:


### PR DESCRIPTION
removing references to python 2.7 from github actions yaml